### PR TITLE
Add public method to align single planes without cropping

### DIFF
--- a/src/main/java/TurboReg_.java
+++ b/src/main/java/TurboReg_.java
@@ -58,6 +58,7 @@ import ij.plugin.PlugIn;
 import ij.plugin.filter.Analyzer;
 import ij.process.FloatProcessor;
 import ij.process.ImageConverter;
+import ij.process.ImageProcessor;
 import ij.process.StackConverter;
 
 // Java 1.1
@@ -857,6 +858,24 @@ public void run (
 		}
 	}
 } /* end run */
+
+/**
+ * Align two image planes with a given alignment method
+ * 
+ * @param ipSource source ImageProcessor
+ * @param ipTarget target ImageProcessor
+ * @param alignmentMethod alignment method (see {@code TurboReg_.turboRegDialog})
+ * 
+ * @return the aligned source image
+ */
+public ImageProcessor alignPlanes(ImageProcessor ipSource, ImageProcessor ipTarget, int alignmentMethod) {
+	ImagePlus impSource = new ImagePlus("Source", ipSource);
+	ImagePlus impTarget = new ImagePlus("Target", ipTarget);
+	int[] sourceCrop = new int[] {0, 0, ipSource.getWidth(), ipSource.getHeight()};
+	int[] targetCrop = new int[] {0, 0, ipTarget.getWidth(), ipTarget.getHeight()};
+	ImagePlus resultImp = alignImages(impSource, sourceCrop, impTarget, targetCrop, alignmentMethod, false);
+	return resultImp.getProcessor();
+}
 
 /*....................................................................
 	Private methods


### PR DESCRIPTION
This change allows to align each slice of a stack to a common reference image (e.g. an average projection of the stack), e.g. with this Groovy script:

``` groovy
// @ImagePlus source
// @ImagePlus target
// @OUTPUT ImagePlus result

import ij.ImagePlus
import ij.ImageStack

tr = new TurboReg_()
targetIp = target.getProcessor()
sourceStack = source.getStack()
n = sourceStack.getSize()

resultStack = new ImageStack(source.getWidth(), source.getHeight())

for (i in 1..n) {
    sourceIp = sourceStack.getProcessor(i)
    resultStack.addSlice(tr.alignPlanes(sourceIp, targetIp, 3))
}

result = new ImagePlus("Aligned", resultStack)
```

This is similar to the behavior of the _Batch_ button in the UI of TurboReg, but it previously wasn't possible to call this from a macro/script.
